### PR TITLE
Mac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ Run the following commands to build the server application.
 1. Clone and compile the C SDK, there are more instructions [here](https://github.com/newrelic/c-sdk).
     1. Use the `make dynamic` command to create the `libnewrelic.so`
 1. Copy `libnewrelic.so` to the server/ directory.
-    1. The `CMakeLists.txt` is setup for linux. To compile the server on a mac the following line will need to be changed from: 
-    ```target_link_libraries (server libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}```
-    To: 
-    ```target_link_libraries (server ${CMAKE_SOURCE_DIR}/libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}```
+    1. The `CMakeLists.txt` is setup for linux. To compile the server on a mac the following line will need to be changed 
+    from: `target_link_libraries (server libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}`
+    to: `target_link_libraries (server ${CMAKE_SOURCE_DIR}/libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}`
 1. Copy `libnewrelic.h` to this projects root directory.
 1. `cmake .`
 1. `make`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Run the following commands to build the server application.
 1. Clone and compile the C SDK, there are more instructions [here](https://github.com/newrelic/c-sdk).
     1. Use the `make dynamic` command to create the `libnewrelic.so`
 1. Copy `libnewrelic.so` to the server/ directory.
+    1. The `CMakeLists.txt` is setup for linux. To compile the server on a mac the following line will need to be changed from: 
+    ```target_link_libraries (server libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}```
+    To: 
+    ```target_link_libraries (server ${CMAKE_SOURCE_DIR}/libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}```
 1. Copy `libnewrelic.h` to this projects root directory.
 1. `cmake .`
 1. `make`

--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ Run the following commands to build the server application.
 1. Clone and compile the C SDK, there are more instructions [here](https://github.com/newrelic/c-sdk).
     1. Use the `make dynamic` command to create the `libnewrelic.so`
 1. Copy `libnewrelic.so` to the server/ directory.
-    1. The `CMakeLists.txt` is setup for linux. To compile the server on a mac the following line will need to be changed 
-    from: `target_link_libraries (server libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}`
-    to: `target_link_libraries (server ${CMAKE_SOURCE_DIR}/libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}`
 1. Copy `libnewrelic.h` to this projects root directory.
 1. `cmake .`
 1. `make`

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package (Threads)
 
 link_directories (../.)
 
-
 add_executable (server server.cpp)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     target_link_libraries (server ${CMAKE_SOURCE_DIR}/libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -12,5 +12,10 @@ link_directories (../.)
 
 
 add_executable (server server.cpp)
-target_link_libraries (server libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries (server ${CMAKE_SOURCE_DIR}/libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}
         pcre dl)
+else()
+    target_link_libraries (server libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}
+        pcre dl)
+endif()

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -4,10 +4,12 @@
 
 # The CMakeLists presumes that libnewrelic.so is in the this directory.
 
+set (CMAKE_CXX_STANDARD 11)
 cmake_minimum_required (VERSION 3.0)
 find_package (Threads)
 
 link_directories (../.)
+
 
 add_executable (server server.cpp)
 target_link_libraries (server libnewrelic.so ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
The CMakeList.txt does not work on mac. Mac needs an absolute path and linux does not like the `CMAKE_SOURCE_DIR` env variable. 